### PR TITLE
Replace deprecated method call to create line item

### DIFF
--- a/Modules/AddToCartModule/View.ascx.cs
+++ b/Modules/AddToCartModule/View.ascx.cs
@@ -135,7 +135,7 @@ namespace Hotcakes.Modules.AddToCartModule
             Order currentCart = HccApp.OrderServices.EnsureShoppingCart();
 
             // create a line item for the cart using the product
-            LineItem li = HccApp.CatalogServices.ConvertProductToLineItem(product, new OptionSelections(), quantity, HccApp);
+            LineItem li = product.ConvertToLineItem(HccApp, quantity, new OptionSelections());
 
             // add the line item to the current cart
             HccApp.AddToOrderWithCalculateAndSave(currentCart, li);


### PR DESCRIPTION
CatalogServices.ConvertProductToLineItem() is deprecated since 1.8.0.  Replaced with Product.ConvertToLineItem(). Resolves #2 
